### PR TITLE
Fix CSS class.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog for dust
 1.1 (unreleased)
 ----------------
 
+- Fix CSS class. The styling was fine with the default Sphinx theme,
+  but incorrect with ReadTheDocs theme.
 - Fix outdated document calculation
 
 

--- a/dust/directive.py
+++ b/dust/directive.py
@@ -57,13 +57,16 @@ class ReviewerMetaDirective(rst.Directive):
             )
             node_list.append(warning)
 
+        options = self.options
+        options['class'] = ['note']
+
         written_strf = datetime.datetime.strftime(written_on, _("Written on %d %B %Y"))
         proofread_strf = datetime.datetime.strftime(proofread_on, _("proofread on %d %B %Y"))
         ad = make_admonition(
             review,
             self.name,
             [_("Review")],
-            self.options,
+            options,
             statemachine.StringList([', '.join([written_strf, proofread_strf])]),
             self.lineno,
             self.content_offset,


### PR DESCRIPTION
It was fine with the default Sphinx theme, but incorrect for the ReadTheDocs theme, with the "Written on..." text unstyled.

Using the "note" CSS class (as for the `note` directive) make it looks better with the RTD theme (and just the same with the default theme). Also, use the `Note` directive as the base class, which looks more specific than `Directive` (although I have no idea what it adds, if anything).

Before:
![css-orig](https://cloud.githubusercontent.com/assets/471321/18482898/4340808a-79e2-11e6-8d03-1ed7f128a6bf.png)

After:

![css-with-patch](https://cloud.githubusercontent.com/assets/471321/18482901/45d52c24-79e2-11e6-96aa-53851717b3e8.png)
