### PR TITLE
directive: Add several settings to customize dust's HTML output [ref #5]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog for dust
 1.2.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add several settings to control dust's HTML output
 
 
 1.2.1 (2017-05-17)

--- a/sphinx_dust/directive.py
+++ b/sphinx_dust/directive.py
@@ -57,15 +57,19 @@ class ReviewerMetaDirective(rst.Directive):
             )
             node_list.append(warning)
 
-        written_strf = datetime.datetime.strftime(written_on, _("Written on %d %B %Y"))
-        proofread_strf = datetime.datetime.strftime(proofread_on, _("proofread on %d %B %Y"))
+        if env.config.dust_include_output:
+            written_str = datetime.datetime.strftime(written_on, env.config.dust_datetime_format)
+            proofread_str = datetime.datetime.strftime(proofread_on, env.config.dust_datetime_format)
 
-        content = statemachine.StringList([', '.join([written_strf, proofread_strf])])
-        review_node = review(content)
-        review_node += nodes.title(_("Review"), _("Review"))
-        self.state.nested_parse(content, self.content_offset, review_node)
+            content = statemachine.StringList([
+                _(env.config.dust_output_format).format(written_on=written_str, proofread_on=proofread_str)
+            ])
+            review_node = review(content)
+            review_node += nodes.title(_("Review"), _("Review"))
+            self.state.nested_parse(content, self.content_offset, review_node)
 
-        node_list.append(review_node)
+            node_list.append(review_node)
+
         return node_list
 
 
@@ -74,6 +78,12 @@ def setup(app):
     app.add_config_value('dust_days_limit', 30, 'html')
     # Whether to emit warning when a doc needs proofreading
     app.add_config_value('dust_emit_warnings', True, 'html')
+    # Whether to include an element in the resulting Sphinx build
+    app.add_config_value('dust_include_output', True, 'html')
+    # Format string for dust output
+    app.add_config_value('dust_output_format', "Written on {written_on}, proofread on {proofread_on}", 'html')
+    # The strftime format to use when outputing written-on and proofread-on values
+    app.add_config_value('dust_datetime_format', '%d %B %Y', 'html')
 
     app.add_node(review, html=(visit_review_node, depart_review_node))
     app.add_directive('reviewer-meta', ReviewerMetaDirective)


### PR DESCRIPTION
Includes:
    - dust_include_output (default: True), whether to include dust's HTML
      output
    - dust_output_format (default: "Written on {written_on}, proofread on
      {proofread_on}"), the content of dust's output
    - dust_datetime_format (default: '%d %B %Y'), the format of dust's
      datetime formatting (included in the output)